### PR TITLE
Add mouse and home button support, TV output toggle, and automatic connection on startup

### DIFF
--- a/src/_platform.c
+++ b/src/_platform.c
@@ -124,6 +124,8 @@ void platform_start(enum platform system) {
     blank_fb("/sys/class/graphics/fb0/blank", true);
     break;
   #endif
+  default:
+    break;
   }
 }
 
@@ -140,6 +142,8 @@ void platform_stop(enum platform system) {
     blank_fb("/sys/class/graphics/fb0/blank", false);
     break;
   #endif
+  default:
+    break;
   }
 }
 
@@ -185,6 +189,8 @@ DECODER_RENDERER_CALLBACKS* platform_get_video(enum platform system) {
   case RK:
     return (PDECODER_RENDERER_CALLBACKS) dlsym(RTLD_DEFAULT, "decoder_callbacks_rk");
   #endif
+  default:
+    break;
   }
   return NULL;
 }
@@ -222,6 +228,8 @@ bool platform_supports_hevc(enum platform system) {
   case AML:
   case RK:
     return true;
+  default:
+    break;
   }
   return false;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -198,6 +198,11 @@ static void stream(PSERVER_DATA server, PCONFIGURATION config, enum platform sys
 #ifdef __WIIU__
 int main(int argc, char* argv[]) {
   WHBProcInit();
+  // `WHBProcInit()` will register a `ProcUI` callback for the user pressing
+  // the HOME button, which just quits the program. We want to use it as an
+  // input and have an alternative way to exit, so we clear the callback before
+  // any others are created. This should be the only callback currently registered.
+  ProcUIClearCallbacks();
 
 #ifdef DEBUG
   Debug_Init();

--- a/src/main.c
+++ b/src/main.c
@@ -265,76 +265,46 @@ int main(int argc, char* argv[]) {
   if (config.debug_level > 0)
     printf("NVIDIA %s, GFE %s (%s, %s)\n", server.gpuType, server.serverInfo.serverInfoGfeVersion, server.gsVersion, server.serverInfo.serverInfoAppVersion);
 
-  while (WHBProcIsRunning()) {
+  wiiu_screen_clear();
+
+  wiiu_screen_print(0, 0, "Moonlight Wii U v1.2 (Connected to %s)", config.address);
+  wiiu_screen_print(0, 1, "=======================================================");
+
+  wiiu_screen_draw();
+
+  while (!server.paired) {
+    char pin[5];
+    sprintf(pin, "%d%d%d%d", (int)random() % 10, (int)random() % 10, (int)random() % 10, (int)random() % 10);
+    printf("Please enter the following PIN on the target PC: %s\n", pin);
     wiiu_screen_clear();
-
-    wiiu_screen_print(0, 0, "Moonlight Wii U v1.2 (Connected to %s)", config.address);
-    wiiu_screen_print(0, 1, "=======================================================");
-    wiiu_screen_print(0, 3, "Press A to stream, Press B to pair");
-
+    wiiu_screen_print(0, 0, "Please enter the following PIN on the target PC: %s\n", pin);
     wiiu_screen_draw();
-
-    uint32_t btns = wiiu_input_buttons_triggered();
-
-    if (btns & VPAD_BUTTON_A) {
-      // stream
-      if (server.paired) {
-        enum platform system = platform_check(config.platform);
-        if (config.debug_level > 0)
-          printf("Platform %s\n", platform_name(system));
-
-        if (system == 0) {
-          fprintf(stderr, "Platform '%s' not found\n", config.platform);
-          wiiu_error_exit("Platform '%s' not found\n", config.platform);
-        }
-        config.stream.supportsHevc = config.codec != CODEC_H264 && (config.codec == CODEC_HEVC || platform_supports_hevc(system));
-
-        stream(&server, &config, system);
-        break;
-      }
-      else {
-        printf("You must pair with the PC first\n");
-        wiiu_screen_clear();
-        wiiu_screen_print(0, 0, "You must pair with the PC first\n");
-        wiiu_screen_draw();
-        sleep(4);
-      }
-    } else if (btns & VPAD_BUTTON_B) {
-      // pair
-      char pin[5];
-      sprintf(pin, "%d%d%d%d", (int)random() % 10, (int)random() % 10, (int)random() % 10, (int)random() % 10);
-      printf("Please enter the following PIN on the target PC: %s\n", pin);
+    if (gs_pair(&server, &pin[0]) != GS_OK) {
+      fprintf(stderr, "Failed to pair to server: %s\n", gs_error);
       wiiu_screen_clear();
-      wiiu_screen_print(0, 0, "Please enter the following PIN on the target PC: %s\n", pin);
+      wiiu_screen_print(0, 0, "Failed to pair to server: %s\n", gs_error);
       wiiu_screen_draw();
-      if (gs_pair(&server, &pin[0]) != GS_OK) {
-        fprintf(stderr, "Failed to pair to server: %s\n", gs_error);
-        wiiu_screen_clear();
-        wiiu_screen_print(0, 0, "Failed to pair to server: %s\n", gs_error);
-        wiiu_screen_draw();
-        sleep(4);
-      } else {
-        printf("Succesfully paired\n");
-        wiiu_screen_clear();
-        wiiu_screen_print(0, 0, "Succesfully paired\n");
-        wiiu_screen_draw();
-        sleep(3);
-      }
-    } 
-    
-    // list
-    // pair_check(&server);
-    // applist(&server);
-    // unpair
-    // if (gs_unpair(&server) != GS_OK) {
-    //   fprintf(stderr, "Failed to unpair to server: %s\n", gs_error);
-    // } else {
-    //   printf("Succesfully unpaired\n");
-    // }
-    // quit
-    // pair_check(&server);
-    // gs_quit_app(&server);
+      sleep(4);
+    } else {
+      printf("Succesfully paired\n");
+      wiiu_screen_clear();
+      wiiu_screen_print(0, 0, "Succesfully paired\n");
+      wiiu_screen_draw();
+      sleep(3);
+    }
   }
+
+  enum platform system = platform_check(config.platform);
+  if (config.debug_level > 0)
+    printf("Platform %s\n", platform_name(system));
+
+  if (system == 0) {
+    fprintf(stderr, "Platform '%s' not found\n", config.platform);
+    wiiu_error_exit("Platform '%s' not found\n", config.platform);
+  }
+  config.stream.supportsHevc = config.codec != CODEC_H264 && (config.codec == CODEC_HEVC || platform_supports_hevc(system));
+
+  stream(&server, &config, system);
 
   wiiu_screen_exit();
   WHBProcShutdown();

--- a/src/main.c
+++ b/src/main.c
@@ -62,9 +62,7 @@
 #include <whb/proc.h>
 #include <coreinit/time.h>
 #include <vpad/input.h>
-#ifdef DEBUG
-void Debug_Init();
-#endif
+#include "wiiu/debug.c"
 #endif
 
 static void applist(PSERVER_DATA server) {

--- a/src/wiiu/input.c
+++ b/src/wiiu/input.c
@@ -3,6 +3,9 @@
 #include <vpad/input.h>
 #include <padscore/kpad.h>
 #include <padscore/wpad.h>
+#include <coreinit/time.h>
+
+#define millis() OSTicksToMilliseconds(OSGetTime())
 
 int disable_gamepad = 0;
 int swap_buttons = 0;
@@ -49,7 +52,13 @@ void wiiu_input_update(void) {
     CHECKBTN(VPAD_BUTTON_STICK_R, RS_CLK_FLAG);
     CHECKBTN(VPAD_BUTTON_PLUS,    PLAY_FLAG);
     CHECKBTN(VPAD_BUTTON_MINUS,   BACK_FLAG);
+    CHECKBTN(VPAD_BUTTON_HOME,    SPECIAL_FLAG);
 #undef CHECKBTN
+
+    static uint64_t home_pressed = 0;
+    // If the button was just pressed, reset to current time
+    if (vpad.trigger & VPAD_BUTTON_HOME) home_pressed = millis();
+    if (btns & VPAD_BUTTON_HOME && millis() - home_pressed > 3000) wiiu_error_exit("Goodbye!");
 
     LiSendMultiControllerEvent(controllerNumber++, gamepad_mask, buttonFlags,
       (vpad.hold & VPAD_BUTTON_ZL) ? 0xFF : 0,

--- a/src/wiiu/input.c
+++ b/src/wiiu/input.c
@@ -10,6 +10,61 @@
 int disable_gamepad = 0;
 int swap_buttons = 0;
 
+char lastTouched = 0;
+
+uint16_t last_x = 0;
+uint16_t last_y = 0;
+
+#define TAP_MILLIS 100
+#define DRAG_DISTANCE 10
+uint64_t touchDownMillis = 0;
+
+void handleTouch(VPADTouchData touch) {
+  // Just pressed (run this twice to allow touch position to settle)
+  if (lastTouched < 2 && touch.touched) {
+    touchDownMillis = millis();
+    last_x = touch.x;
+    last_y = touch.y;
+
+    lastTouched++;
+    return; // We can't do much until we wait for a few hundred milliseconds
+            // since we don't know if it's a tap, a tap-and-hold, or a drag
+  }
+
+  // Just released
+  if (lastTouched && !touch.touched) {
+    if (millis() - touchDownMillis < TAP_MILLIS) {
+      LiSendMouseButtonEvent(BUTTON_ACTION_PRESS, BUTTON_LEFT);
+      sleep(0.1);
+      LiSendMouseButtonEvent(BUTTON_ACTION_RELEASE, BUTTON_LEFT);
+    }
+  }
+
+  if (touch.touched) {
+    // Holding & dragging screen, not just tapping
+    if (millis() - touchDownMillis > TAP_MILLIS || touchDownMillis == 0) {
+      if (touch.x != last_x || touch.y != last_y) // Don't send extra data if we don't need to
+        LiSendMouseMoveEvent(touch.x - last_x, touch.y - last_y);
+      last_x = touch.x;
+      last_y = touch.y;
+    } else {
+      if (touch.x - last_x < -10 || touch.x - last_x > 10) touchDownMillis=0;
+      if (touch.y - last_y < -10 || touch.y - last_y > 10) touchDownMillis=0;
+      int16_t diff_x = touch.x - last_x;
+      int16_t diff_y = touch.y - last_y;
+      if (diff_x < 0) diff_x = -diff_x;
+      if (diff_y < 0) diff_y = -diff_y;
+      if (diff_x + diff_y > DRAG_DISTANCE) touchDownMillis = 0;
+    }
+  }
+
+  // Absolute positioning:
+  // LiSendMousePositionEvent(touch.x, touch.y, WIDTH, HEIGHT);
+
+
+  lastTouched = touch.touched ? lastTouched : 0; // Keep value unless released
+}
+
 void wiiu_input_init(void)
 {
 	KPADInit();
@@ -65,6 +120,10 @@ void wiiu_input_update(void) {
       (vpad.hold & VPAD_BUTTON_ZR) ? 0xFF : 0,
       vpad.leftStick.x * INT16_MAX, vpad.leftStick.y * INT16_MAX,
       vpad.rightStick.x * INT16_MAX, vpad.rightStick.y * INT16_MAX);
+
+    VPADTouchData touch;
+    VPADGetTPCalibratedPoint(VPAD_CHAN_0, &touch, &vpad.tpNormal);
+    handleTouch(touch);
   }
 
   KPADStatus kpad_data = {0};

--- a/src/wiiu/wiiu.c
+++ b/src/wiiu/wiiu.c
@@ -103,14 +103,13 @@ void wiiu_init(uint32_t width, uint32_t height)
 void wiiu_loop(void)
 {
   while(WHBProcIsRunning()) {
+    wiiu_input_update();
     yuv_texture_t* tex = get_frame();
     if (tex) {
       if (++currentFrame <= nextFrame - NUM_BUFFERS) {
         // display thread is behind decoder, skip frame
-      } 
+      }
       else {
-        wiiu_input_update();
-
         WHBGfxBeginRender();
 
         // TV

--- a/src/wiiu/wiiu.c
+++ b/src/wiiu/wiiu.c
@@ -216,6 +216,8 @@ void wiiu_error_exit(char* fmt, ...)
 
   wiiu_screen_draw();
 
+  // Re-enable home button detection for exit
+  WHBProcInit();
   while (WHBProcIsRunning());
 
   wiiu_screen_exit();


### PR DESCRIPTION
This PR adds mouse support (with the touchscreen, drag to move mouse and tap to click), forwards the home button (press and hold for 3 seconds to exit). It also skips the "press A to stream/B to pair" screen, instead automatically pairing on startup (if needed), then starting streaming. Finally, it fixes a few minor compiler warnings (due to missing `default:` clauses inside `switch`es) and an error when building if you `#define DEBUG`.