### PR TITLE
Add support for saving multiple host addresses

### DIFF
--- a/moonlight.conf
+++ b/moonlight.conf
@@ -1,7 +1,7 @@
 ## Moonlight Wii U Configuration
 ## Lines starting with '#' are comments, to edit an option uncomment it by removing the '#'
 
-## Hostname or IP-address of host to connect to
+## Hostname or IP-address of host to connect to (you can add multiple hosts)
 #address = 1.2.3.4
 
 ## Video streaming configuration

--- a/src/config.c
+++ b/src/config.c
@@ -293,8 +293,8 @@ static void parse_argument(int c, char* value, PCONFIGURATION config) {
   case 1:
     if (config->action == NULL)
       config->action = strdup(value);
-    else if (config->address == NULL)
-      config->address = strdup(value);
+    else if (config->address[0] == NULL)
+      config->address[0] = strdup(value);
     else {
       perror("Too many options");
       exit(-1);
@@ -328,7 +328,12 @@ bool config_file_parse(char* filename, PCONFIGURATION config) {
     if (sscanf(line, "%1023s = %4095s[^\n]", key, value) == 2) {
 #endif
       if (strcmp(key, "address") == 0) {
-        config->address = strdup(value);
+        if (config->addressCount >= MAX_ADDRESS) {
+          perror("Too many addresses specified");
+          exit(-1);
+        }
+        config->address[config->addressCount] = strdup(value);
+        config->addressCount++;
       } else if (strcmp(key, "sops") == 0) {
         config->sops = strcmp("true", value) == 0;
       } else {
@@ -422,7 +427,7 @@ void config_parse(int argc, char* argv[], PCONFIGURATION config) {
   config->platform = "auto";
   config->app = "Steam";
   config->action = NULL;
-  config->address = NULL;
+  config->address[0] = NULL;
   config->config_file = NULL;
   config->audio_device = NULL;
   config->sops = true;
@@ -439,6 +444,7 @@ void config_parse(int argc, char* argv[], PCONFIGURATION config) {
   config->port = 47989;
 
   config->inputsCount = 0;
+  config->addressCount = 0;
 
 #ifndef __WIIU__
   config->codec = CODEC_UNSPECIFIED;

--- a/src/config.h
+++ b/src/config.h
@@ -21,6 +21,7 @@
 
 #include <stdbool.h>
 
+#define MAX_ADDRESS 6
 #define MAX_INPUTS 6
 
 enum codecs { CODEC_UNSPECIFIED, CODEC_H264, CODEC_HEVC, CODEC_AV1 };
@@ -30,7 +31,8 @@ typedef struct _CONFIGURATION {
   int debug_level;
   char* app;
   char* action;
-  char* address;
+  char* address[MAX_ADDRESS];
+  int addressCount;
   char* mapping;
   char* platform;
   char* audio_device;

--- a/src/main.c
+++ b/src/main.c
@@ -230,7 +230,7 @@ int main(int argc, char* argv[]) {
           Font_SetColor(0, 255, 0, 255);
         }
         Font_SetSize(50);
-        Font_Print(8, 400, message_buffer);
+        Font_Print(8, 700, message_buffer);
 
         Font_Draw_TVDRC();
 
@@ -325,7 +325,7 @@ int main(int argc, char* argv[]) {
           Font_SetColor(0, 255, 0, 255);
         }
         Font_SetSize(50);
-        Font_Print(8, 400, message_buffer);
+        Font_Print(8, 500, message_buffer);
         Font_Draw_TVDRC();
 
         uint32_t btns = wiiu_input_buttons_triggered();

--- a/src/main.c
+++ b/src/main.c
@@ -316,7 +316,7 @@ int main(int argc, char* argv[]) {
 
         Font_Printf(8, 58, "Moonlight Wii U %s (Connected to %s)\n"
                            SCREEN_BAR
-                           "Press \ue000 to stream\nPress \ue001 to pair\n", VERSION_STRING, config.address);
+                           "Press \ue000 to stream\nPress \ue002 to pair\n\nPress \ue001 to go back\n", VERSION_STRING, cur_address);
 
         if (is_error) {
           Font_SetColor(255, 0, 0, 255);
@@ -332,10 +332,15 @@ int main(int argc, char* argv[]) {
         if (btns & VPAD_BUTTON_A) {
           message_buffer[0] = '\0';
           state = STATE_START_STREAM;
-        } else if (btns & VPAD_BUTTON_B) {
+        } else if (btns & VPAD_BUTTON_X) {
           message_buffer[0] = '\0';
           state = STATE_PAIRING;
         }
+        else if (btns & VPAD_BUTTON_B) {
+          message_buffer[0] = '\0';
+          state = STATE_DISCONNECTED;
+        }
+        
         break;
       }
       case STATE_PAIRING: {


### PR DESCRIPTION
Add support for setting multiple hosts in the config file by repeating the `address` key.

Potential next steps:
- add option to select a host to automatically connect to when multiple options are present
- load host config file when selecting host to allow different options for different hosts (i.e. different bitrate for LAN and WAN IPs)
- allow setting friendly names for hosts