### PR TITLE
Gyroscope support for moonlight wii u

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ Moonlight Wii U is a port of [Moonlight Embedded](https://github.com/moonlight-s
 > :information_source: A Wii U LAN Adapter is recommended!
 
 * compile this "GYRO" version (with the docker file, it's the easiest way in my opinion), extract it to the root of your SD Card.
-* Enter the IP of your Sunshine/GFE server in the `moonlight.conf` file located at `sd:/wiiu/apps/moonlight`.
-* Ensure your Sunshine/GFE server and Wii U are on the same network.
+* Enter the IP of your Sunshine server in the `moonlight.conf` file located at `sd:/wiiu/apps/moonlight`.
+* Ensure your Sunshine server and Wii U are on the same network.
 * Ensure to set the gamepad to DS4 in sunshine host.
-* If using GFE, turn on Shield Streaming in the GFE settings.
+* If your button are swapped, activate swap button in moonlight.conf
+* Don't use GFE, use only sunshine for this version.
 * Pair Moonlight Wii U with the server.
 * Accept the pairing confirmation on your PC.
 * Connect to the server with Moonlight Wii U.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Moonlight Wii U is a port of [Moonlight Embedded](https://github.com/moonlight-s
 
 > :information_source: A Wii U LAN Adapter is recommended!
 
-* compile this "GYRO" version (with the docker file, it's the easiest way in my opinion), extract it to the root of your SD Card.
+* Compile this gyroscope version (with the docker file, it's the easiest way in my opinion), extract it to the root of your SD Card.
 * Enter the IP of your Sunshine server in the `moonlight.conf` file located at `sd:/wiiu/apps/moonlight`.
 * Ensure your Sunshine server and Wii U are on the same network.
 * Ensure to set the gamepad to DS4 in sunshine host.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# DS4 Gyroscope support for Sunshine Hosts !!
+This version add true Gyroscope support to the wii U gamepad client.
+
 # Moonlight Wii U
 
 Moonlight Wii U is a port of [Moonlight Embedded](https://github.com/moonlight-stream/moonlight-embedded), which is an open source client for [Sunshine](https://github.com/LizardByte/Sunshine) and NVIDIA GameStream. Moonlight allows you to stream your full collection of games and applications from your PC to other devices to play them remotely.
@@ -6,9 +9,10 @@ Moonlight Wii U is a port of [Moonlight Embedded](https://github.com/moonlight-s
 
 > :information_source: A Wii U LAN Adapter is recommended!
 
-* Grab the latest version from the [releases page](https://github.com/GaryOderNichts/moonlight-wiiu/releases) and extract it to the root of your SD Card.
+* compile this "GYRO" version (with the docker file, it's the easiest way in my opinion), extract it to the root of your SD Card.
 * Enter the IP of your Sunshine/GFE server in the `moonlight.conf` file located at `sd:/wiiu/apps/moonlight`.
 * Ensure your Sunshine/GFE server and Wii U are on the same network.
+* Ensure to set the gamepad to DS4 in sunshine host.
 * If using GFE, turn on Shield Streaming in the GFE settings.
 * Pair Moonlight Wii U with the server.
 * Accept the pairing confirmation on your PC.

--- a/src/wiiu/input.c
+++ b/src/wiiu/input.c
@@ -187,12 +187,6 @@ void wiiu_input_update(void) {
       vpad.leftStick.x * INT16_MAX, vpad.leftStick.y * INT16_MAX,
       vpad.rightStick.x * INT16_MAX, vpad.rightStick.y * INT16_MAX);
 
-    //   LiSendControllerMotionEvent(idx,
-    //                               accelX, accelY, accelZ,
-    //                               gyroPitch, gyroYaw, gyroRoll);
-    // }
-    // // ----------------------------------------------------------------
-
     VPADTouchData touch;
     VPADGetTPCalibratedPoint(VPAD_CHAN_0, &touch, &vpad.tpNormal);
     handleTouch(touch);


### PR DESCRIPTION
These changes add the long awaited gyroscope support to moonlight Wii U :

Tested and working : Wii U gamepad gyroscope (only for the Wii U gamepad )
You must set the gamepad setting to DS4 in sunshine host
You might have to swap button in moonlight.conf
I think the conversion to rad/s2 is ok
I'm not 100% sure all the parameter for the accelerometers are optimal, but they work ok for me