### PR TITLE
Add touchscreen emulation support

### DIFF
--- a/moonlight.conf
+++ b/moonlight.conf
@@ -18,8 +18,10 @@
 ## Automatically connect to the host on startup and start the stream
 #autostream = true
 
-## Use the absolute touch position for mouse emulation
-#absolute_positioning = true
+## Changes the way touchscreen inputs are sent to the host
+## relative (default) - mouse behaves similarly to a touchpad
+## absolute - mouse moves to the exact touch position
+# mouse_mode = relative
 
 ## Output rotation (independent of xrandr or framebuffer settings!)
 ## Allowed values: 0, 90, 180, 270

--- a/moonlight.conf
+++ b/moonlight.conf
@@ -21,6 +21,7 @@
 ## Changes the way touchscreen inputs are sent to the host
 ## relative (default) - mouse behaves similarly to a touchpad
 ## absolute - mouse moves to the exact touch position
+## touchsceen - emulates touchscreen inputs on the host
 # mouse_mode = relative
 
 ## Output rotation (independent of xrandr or framebuffer settings!)

--- a/src/config.c
+++ b/src/config.c
@@ -279,6 +279,8 @@ static void parse_argument(int c, char* value, PCONFIGURATION config) {
       mouse_mode = MOUSE_MODE_RELATIVE;
     else if (strcasecmp(value, "absolute") == 0)
       mouse_mode = MOUSE_MODE_ABSOLUTE;
+    else if (strcasecmp(value, "touchscreen") == 0)
+      mouse_mode = MOUSE_MODE_TOUCHSCREEN;
     break;
 #endif
   case '4':

--- a/src/config.c
+++ b/src/config.c
@@ -31,7 +31,7 @@
 #ifdef __WIIU__
 extern int disable_gamepad;
 extern int swap_buttons;
-extern int absolute_positioning;
+extern mouse_modes mouse_mode;
 extern int autostream;
 
 extern ssize_t getline(char **buf, size_t *bufsiz, FILE *fp);
@@ -83,7 +83,7 @@ static struct option long_options[] = {
   {"disable_gamepad", no_argument, NULL, 'A'},
   {"swap_buttons", no_argument, NULL, 'B'},
   {"autostream", no_argument, NULL, 'C'},
-  {"absolute_positioning", no_argument, NULL, 'D'},
+  {"mouse_mode", required_argument, NULL, 'D'},
 #endif
   {"nomouseemulation", no_argument, NULL, '4'},
   {"pin", required_argument, NULL, '5'},
@@ -275,7 +275,10 @@ static void parse_argument(int c, char* value, PCONFIGURATION config) {
     autostream = true;
     break;
   case 'D':
-    absolute_positioning = true;
+    if (strcasecmp(value, "relative") == 0)
+      mouse_mode = MOUSE_MODE_RELATIVE;
+    else if (strcasecmp(value, "absolute") == 0)
+      mouse_mode = MOUSE_MODE_ABSOLUTE;
     break;
 #endif
   case '4':

--- a/src/config.h
+++ b/src/config.h
@@ -25,6 +25,11 @@
 
 enum codecs { CODEC_UNSPECIFIED, CODEC_H264, CODEC_HEVC, CODEC_AV1 };
 
+typedef enum mouse_modes {
+  MOUSE_MODE_RELATIVE,
+  MOUSE_MODE_ABSOLUTE
+} mouse_modes;
+
 typedef struct _CONFIGURATION {
   STREAM_CONFIGURATION stream;
   int debug_level;

--- a/src/config.h
+++ b/src/config.h
@@ -27,7 +27,8 @@ enum codecs { CODEC_UNSPECIFIED, CODEC_H264, CODEC_HEVC, CODEC_AV1 };
 
 typedef enum mouse_modes {
   MOUSE_MODE_RELATIVE,
-  MOUSE_MODE_ABSOLUTE
+  MOUSE_MODE_ABSOLUTE,
+  MOUSE_MODE_TOUCHSCREEN
 } mouse_modes;
 
 typedef struct _CONFIGURATION {

--- a/src/wiiu/input.c
+++ b/src/wiiu/input.c
@@ -51,6 +51,20 @@ void handleTouch(VPADTouchData touch) {
       touched = 0;
     }
   }
+  else if (mouse_mode == MOUSE_MODE_TOUCHSCREEN) {
+    if (touch.touched) {
+      if (!touched) {
+        LiSendTouchEvent(LI_TOUCH_EVENT_DOWN, 0, (float) touch.x / TOUCH_WIDTH, (float) touch.y / TOUCH_HEIGHT, 0.0, 0.0, 0.0, 0.0);
+        touched = 1;
+      } else {
+        LiSendTouchEvent(LI_TOUCH_EVENT_MOVE, 0, (float) touch.x / TOUCH_WIDTH, (float) touch.y / TOUCH_HEIGHT, 0.0, 0.0, 0.0, 0.0);
+      }
+    }
+    else if (touched) {
+      LiSendTouchEvent(LI_TOUCH_EVENT_UP, 0, (float) touch.x / TOUCH_WIDTH, (float) touch.y / TOUCH_HEIGHT, 0.0, 0.0, 0.0, 0.0);
+      touched = 0;
+    }
+  }
   else {
     // Just pressed (run this twice to allow touch position to settle)
     if (lastTouched < 2 && touch.touched) {

--- a/src/wiiu/input.c
+++ b/src/wiiu/input.c
@@ -1,3 +1,4 @@
+#include "../config.h"
 #include "wiiu.h"
 
 #include <malloc.h>
@@ -13,7 +14,7 @@
 
 int disable_gamepad = 0;
 int swap_buttons = 0;
-int absolute_positioning = 0;
+mouse_modes mouse_mode = MOUSE_MODE_RELATIVE;
 
 static char lastTouched = 0;
 static char touched = 0;
@@ -36,7 +37,7 @@ static OSAlarm inputAlarm;
 #define INPUT_UPDATE_RATE OSMillisecondsToTicks(16)
 
 void handleTouch(VPADTouchData touch) {
-  if (absolute_positioning) {
+  if (mouse_mode == MOUSE_MODE_ABSOLUTE) {
     if (touch.touched) {
       LiSendMousePositionEvent(touch.x, touch.y, TOUCH_WIDTH, TOUCH_HEIGHT);
 


### PR DESCRIPTION
This PR adds support for touchscreen emulation. Any inputs on the GamePad screen get sent as native touchscreen inputs to the host when it is enabled. This enables support for touchscreen gestures such as scrolling on Windows, and I assume on other host-systems as well.

The `absolute_positioning` config-variable was replaced with a `mouse_mode` enum to switch between `relative`, `absolute` and `touchscreen` mouse input modes. Notes that this change would break older configs.